### PR TITLE
Add Rectangle app to the list

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -6990,6 +6990,22 @@
           "categories" : [
             "productivity"
           ]
+        },
+        {
+            "short_description": "Rectangle is a window manager heavily based on Spectacle, written in Swift.",
+            "categories": [
+                "window-management"
+            ],
+            "repo_url": "https://github.com/rxhanson/Rectangle",
+            "title": "Rectangle",
+            "icon_url": "https://rectangleapp.com/images/appIconNoShadow512.png",
+            "screenshots": [
+                "https://rectangleapp.com/images/ScreenShot.png"
+            ],
+            "official_site": "https://rectangleapp.com",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/rxhanson/Rectangle

## Category
window-management

## Description
Rectangle is a window manager heavily based on Spectacle, written in Swift.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
Spectacle (also in this list) hasn't been maintained in ~2 years. Rectangle brings almost all of the functionality of Spectacle into Swift and adds in some more updates. The custom (and often buggy) shortcut recorder in Spectacle is replaced with the popular and stable MASShortcut library. 

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
